### PR TITLE
add iso3166 code of Republic of Kosovo

### DIFF
--- a/src/misc/Iso3166Alpha2.php
+++ b/src/misc/Iso3166Alpha2.php
@@ -258,6 +258,7 @@ class Iso3166Alpha2
 		'WS' => 'Samoa',
 		'YE' => 'Yemen',
 		'YT' => 'Mayotte',
+		'XK' => 'Republic of Kosovo',
 		'ZA' => 'South Africa',
 		'ZM' => 'Zambia',
 		'ZW' => 'Zimbabwe',


### PR DESCRIPTION
Republic of Kosovo was missing in the ISO 3166 file.

Reference: https://en.wikipedia.org/wiki/Kosovo